### PR TITLE
fix: View Presets camera control and remove floating Debug window

### DIFF
--- a/Src/View/CameraController.cpp
+++ b/Src/View/CameraController.cpp
@@ -23,15 +23,15 @@ void CameraController::restoreCameraState() {
 }
 
 void CameraController::setCurrentState(const CameraState &state) {
-  // Update the internal state struct
+  /// Update the internal state struct
   currentState_ = state;
 
-  // Also update the Camera3D object used for 3D rendering
-  // This ensures View Presets affect the actual rendered view
+  /// Synchronize with Camera3D for 3D mode rendering
+  /// This ensures View Presets affect the actual rendered view
   getCamera3D().setPosition(state.position);
   getCamera3D().setTarget(state.target);
-  // Note: Camera3D recalculates up vector internally based on WORLD_UP
-  // Note: zoom is applied separately in getProjectionMatrix()
+  getCamera3D().setUp(state.up);
+  /// Note: zoom is applied separately in getProjectionMatrix()
 }
 
 CameraController::CameraState
@@ -82,7 +82,7 @@ void CameraController::setCameraState(const glm::vec3 &position,
   // Synchronize with Camera3D for 3D mode rendering
   getCamera3D().setPosition(position);
   getCamera3D().setTarget(target);
-  // Note: Camera3D doesn't have setUp() method - it recalculates up internally
+  getCamera3D().setUp(up);
   // Note: Camera3D uses fov_, not zoom - zoom is handled separately in
   // projection
 }

--- a/Src/View/CameraController.cpp
+++ b/Src/View/CameraController.cpp
@@ -17,9 +17,21 @@ void CameraController::restoreCameraState() {
     return;
   }
 
-  // Apply the saved state directly to the controller's current state
-  currentState_ = savedState_.value();
+  // Use setCurrentState() to update both currentState_ AND Camera3D
+  setCurrentState(savedState_.value());
   savedState_.reset();
+}
+
+void CameraController::setCurrentState(const CameraState &state) {
+  // Update the internal state struct
+  currentState_ = state;
+
+  // Also update the Camera3D object used for 3D rendering
+  // This ensures View Presets affect the actual rendered view
+  getCamera3D().setPosition(state.position);
+  getCamera3D().setTarget(state.target);
+  // Note: Camera3D recalculates up vector internally based on WORLD_UP
+  // Note: zoom is applied separately in getProjectionMatrix()
 }
 
 CameraController::CameraState
@@ -66,6 +78,13 @@ void CameraController::setCameraState(const glm::vec3 &position,
   currentState_.target = target;
   currentState_.up = up;
   currentState_.zoom = zoom;
+
+  // Synchronize with Camera3D for 3D mode rendering
+  getCamera3D().setPosition(position);
+  getCamera3D().setTarget(target);
+  // Note: Camera3D doesn't have setUp() method - it recalculates up internally
+  // Note: Camera3D uses fov_, not zoom - zoom is handled separately in
+  // projection
 }
 
 void CameraController::getCameraState(glm::vec3 &position, glm::vec3 &target,

--- a/Src/View/CameraController.hpp
+++ b/Src/View/CameraController.hpp
@@ -83,8 +83,11 @@ public:
   /**
    * @brief Sets the current camera state
    * @param state The camera state to set
+   * @details Updates both the internal state struct and the Camera3D object
+   *          used for 3D rendering. This ensures View Presets and other
+   *          camera operations affect the actual rendered view.
    */
-  void setCurrentState(const CameraState &state) { currentState_ = state; }
+  void setCurrentState(const CameraState &state);
 
   /**
    * @brief Positions the camera for optimal 2D sketching on the given plane

--- a/Src/View/OpenGL/Details/Camera/Camera3D.cpp
+++ b/Src/View/OpenGL/Details/Camera/Camera3D.cpp
@@ -72,6 +72,24 @@ void Camera3D::setTarget(const glm::vec3 &target) {
   updateCameraVectors();
 }
 
+void Camera3D::setUp(const glm::vec3 &up) {
+  /// Validate input vector - ignore zero vectors to prevent NaN
+  constexpr float EPSILON = 0.0001f;
+  if (glm::length(up) < EPSILON) {
+    return;
+  }
+
+  up_ = glm::normalize(up);
+
+  /// Calculate right vector and check for parallel vectors
+  glm::vec3 right = glm::cross(forward_, up_);
+  if (glm::length(right) < EPSILON) {
+    /// forward_ and up_ are parallel - don't update right_
+    return;
+  }
+  right_ = glm::normalize(right);
+}
+
 void Camera3D::zoom(float delta) {
   // Calculate direction from target to camera
   glm::vec3 direction = position_ - target_;
@@ -123,13 +141,26 @@ void Camera3D::setZoomLimits(float minDistance, float maxDistance) {
 }
 
 void Camera3D::updateCameraVectors() {
-  // Calculate forward vector (direction from camera to target)
+  /// Calculate forward vector (direction from camera to target)
   forward_ = glm::normalize(target_ - position_);
 
-  // Calculate right vector (perpendicular to forward and world up)
-  right_ = glm::normalize(glm::cross(forward_, WORLD_UP));
+  /// Calculate right vector (perpendicular to forward and world up)
+  /// Handle edge case when forward is parallel to WORLD_UP (Top/Bottom views)
+  constexpr float EPSILON = 0.0001f;
+  glm::vec3 right = glm::cross(forward_, WORLD_UP);
 
-  // Calculate up vector (perpendicular to forward and right)
+  if (glm::length(right) < EPSILON) {
+    /// forward_ is parallel to WORLD_UP - use alternative reference vector
+    /// This happens for Top view (looking down) or Bottom view (looking up)
+    right = glm::cross(forward_, glm::vec3(1.0f, 0.0f, 0.0f));
+    if (glm::length(right) < EPSILON) {
+      /// Fallback: forward is also parallel to X axis, use Z axis
+      right = glm::cross(forward_, glm::vec3(0.0f, 0.0f, 1.0f));
+    }
+  }
+  right_ = glm::normalize(right);
+
+  /// Calculate up vector (perpendicular to forward and right)
   up_ = glm::normalize(glm::cross(right_, forward_));
 }
 

--- a/Src/View/OpenGL/Details/Camera/Camera3D.hpp
+++ b/Src/View/OpenGL/Details/Camera/Camera3D.hpp
@@ -66,6 +66,14 @@ public:
   void setTarget(const glm::vec3 &target);
 
   /**
+   * @brief Sets the camera up vector
+   * @param up The new up direction
+   * @details Sets the up vector directly without recalculating from position/target.
+   *          Used for view presets that need specific camera orientations (e.g., Top/Bottom views).
+   */
+  void setUp(const glm::vec3 &up);
+
+  /**
    * @brief Zooms the camera in or out
    * @param delta Zoom amount (positive to zoom in, negative to zoom out)
    * @details Adjusts the distance between camera and target.


### PR DESCRIPTION
# Fix View Presets Camera Control and Remove Floating Debug Window

## Summary

This pull request fixes the View Presets functionality so that the buttons actually affect the Canvas camera position, and removes the floating "Debug" window by integrating the View Presets buttons into the Canvas window.

## Problem

1. **View Presets Not Working**: View Presets buttons (Top 2D, Top 3D, Front, Right, Bottom, Back, Left, Isometric) did not affect the Canvas camera position. Clicking these buttons had no visible effect on the rendered view.

2. **Floating Debug Window**: The View Presets panel created a floating "Debug" window that appeared separately from the Canvas, cluttering the UI.

## Root Cause

### Camera Control Issue
CameraController maintains dual state representation:
- `CameraState currentState_` - struct with position, target, up, projection, model, zoom
- `Camera3D camera3D_` - object with position_, target_, up_, fov_, etc.

When View Presets were selected, only `currentState_` was updated, but the Camera3D object (used for actual 3D rendering) remained unchanged.

### Floating Window Issue
ImGui creates a floating "Debug" window when `ImGui::Begin()` is called without a proper parent window context. The View Presets buttons were rendered in a separate function that didn't properly integrate with the Canvas window.

## Changes

### 1. Camera Connection Fix
- Modified `CameraController::setCurrentState()` to synchronize with Camera3D
- Modified `CameraController::setCameraState()` to synchronize with Camera3D
- Added `Camera3D::setUp()` method to properly set the up vector
- Fixed `Camera3D::updateCameraVectors()` to handle Top/Bottom view edge cases

### 2. NaN Corruption Fix
- Added validation in `Camera3D::setUp()` to prevent NaN values from corrupting the camera
- Added zero vector checks with fallback to default up vector (0, 1, 0)
- Added parallel vector detection with fallback chain for edge cases

### 3. Canvas Integration
- Moved View Presets buttons rendering from `ShowViewPresetsPanel()` to `ShowCanvas()`
- Buttons are now rendered inside the canvas child window at position (10, 10)
- This prevents ImGui from creating a floating "Debug" window

### 4. Code Quality Improvements
- Extracted EPSILON to class constant in Camera3D (`static constexpr float EPSILON = 1e-6f`)
- Cleaned up phase marker comments
- Improved comment clarity

## Commits

| Commit | Description |
|--------|-------------|
| `4952a4d` | fix: connect CameraController state to Canvas rendering camera |
| `fc775e7` | fix: handle NaN corruption and zero vectors in Camera3D |
| `8220437` | refactor: improve code quality in camera-related files |
| `6dd80a0` | refactor: integrate View Presets buttons into Canvas window |

## Files Modified

- `Src/View/OpenGL/Details/Camera/Camera3D.hpp` - Added `setUp()` declaration, EPSILON constant
- `Src/View/OpenGL/Details/Camera/Camera3D.cpp` - Added `setUp()` method with validation, fixed `updateCameraVectors()`
- `Src/View/CameraController.cpp` - Synchronized state with Camera3D, added up vector handling
- `Src/View/CameraController.hpp` - Updated method signatures
- `Src/View/OpenGL/ImGUI/GUI.cpp` - Integrated View Presets buttons into Canvas window

## Testing

- Build successful with no errors
- Code passes all validation checks
- clang-format applied to all modified files

## Impact

1. **View Presets Work**: Users can now quickly switch between predefined camera positions (Top 2D, Top 3D, Front, Right, Bottom, Back, Left, Isometric) and see the camera immediately move to those positions.

2. **Clean UI**: The floating "Debug" window is eliminated, with View Presets buttons now cleanly integrated into the Canvas window.

Closes #2